### PR TITLE
Some minor changes to support python 2.6, and addition of some options

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,11 @@
 {
   "name":"LRIT Files DAEMON",
+  "address": "address",
+  "port": 4001,
   "version":"0.1",
   "verbose": {
-    "tuned_frame":0,
-    "tuned_packet":0
+    "tuned_frame":1,
+    "tuned_packet":1
   },
   "base_directory":"/usr/apps/lrit_files/data",
   "channel":{

--- a/lrit.py
+++ b/lrit.py
@@ -218,7 +218,6 @@ class LRIT:
       data_len = len( data )
       if data_len < 6:                   # too short to be complete, abort
         return
-      print repr(data[0:6])
       ( id, seq, length ) = struct.unpack( "!HHH", buffer(data[0:6]) )
       length += 1                        # length = octets in data *minus one*
       self.version        = ( id & 0xe000 ) >> 13
@@ -317,7 +316,7 @@ if __name__ == '__main__':
 
   rs = reedsolomon( 8, 16, 112, 11, 0, 4, 0, 1 )
 
-  for frame in LRIT( '130.165.21.239', file=filename ):
+  for frame in LRIT( cfg("address"), port=cfg("port"), file=filename ):
     if not tuning( frame.channel ):
       continue
     chan = channel[frame.channel]

--- a/lrit.py
+++ b/lrit.py
@@ -302,13 +302,20 @@ def cfg( *indices ):
     cf = cf[index]
   return cf
 
+def parseArgs():
+  import optparse
+  parser=optparse.OptionParser()
+  parser.add_option('-c', '--config', dest='config', default="/usr/apps/lrit_files/script/config.json", help="JSON config file", metavar="CONFIGFILE")
+  parser.add_option('-f', '--file', dest='filename', default=None, help="File of data to test data from instead of connecting live data.", metavar="DATAFILE" )
+
+  return parser.parse_args()[0] # note, this will need to be changed if anyone wants to add non-named arguments
+
 if __name__ == '__main__':
-  config = '/usr/apps/lrit_files/script/config.json'
-  config = 'config.json'
+  args = parseArgs()
+  config = args.config
   conf = json.loads( ''.join( open( config ).readlines() ) )
-  filename = None
-  if len( sys.argv ) > 1:
-    filename = sys.argv[1]
+  filename = args.filename
+  if filename is not None:
     print "Reading satellite data from file: ", filename
   channel = []
   for chan in range( 64 ):


### PR DESCRIPTION
Python 2.6 doesn't support bytearrays in many of the functions, like write and unpack, and 2.6 is the current default installed python as far as I can tell.

I also added some options: address and port in config.json, as well as command line options to specify the config file and the data file for testing.
